### PR TITLE
kuromojiライブラリの更新とプロジェクトをutf-8化

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ version = "0.0.2"
 sourceCompatibility = targetCompatibility = '1.8'
 repositories.mavenCentral()
 
+def defaultEncoding = 'UTF-8'
+tasks.withType(AbstractCompile)*.options*.encoding = defaultEncoding
+tasks.withType(GroovyCompile)*.groovyOptions*.encoding = defaultEncoding
+
 repositories {
     maven {
         // Atilika Open Source repository (for kuromoji)

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories.mavenCentral()
 repositories {
     maven {
         // Atilika Open Source repository (for kuromoji)
-        url "http://www.atilika.org/nexus/content/repositories/atilika"
+        url "https://oss.sonatype.org/content/repositories/comatilika-1002"
     }
 }
 
@@ -37,7 +37,7 @@ idea {
 }
  
 dependencies {
-    compile "org.atilika.kuromoji:kuromoji:0.7.7"
+    compile "com.atilika.kuromoji:kuromoji-ipadic:0.9.0"
     provided "org.projectlombok:lombok:1.16.4"
     testCompile 'junit:junit:4.12'
 }
@@ -74,11 +74,11 @@ uploadArchives {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+                authentication(userName: hasProperty('ossrhUsername')?ossrhUsername:'', password: hasProperty('ossrhPassword')?ossrhPassword:'')
             }
 
             snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+                authentication(userName: hasProperty('ossrhUsername')?ossrhUsername:'', password: hasProperty('ossrhPassword')?ossrhPassword:'')
             }
 
             pom.project {

--- a/src/main/java/com/github/masahitojp/nineteen/Parser.java
+++ b/src/main/java/com/github/masahitojp/nineteen/Parser.java
@@ -1,12 +1,12 @@
 package com.github.masahitojp.nineteen;
 
-import org.atilika.kuromoji.Tokenizer;
+import com.atilika.kuromoji.ipadic.Tokenizer;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class Parser {
-    protected static Tokenizer tokenizer = Tokenizer.builder().build();
+    protected static Tokenizer tokenizer = new Tokenizer();
 
     public static List<Token> parse(final String text) {
         return tokenizer.tokenize(text).stream().map(Token::new)

--- a/src/main/java/com/github/masahitojp/nineteen/Token.java
+++ b/src/main/java/com/github/masahitojp/nineteen/Token.java
@@ -9,10 +9,10 @@ import java.util.regex.Pattern;
 
 
 public class Token {
-    private final org.atilika.kuromoji.Token token;
+    private final com.atilika.kuromoji.ipadic.Token token;
     private final String[] feature;
 
-    public Token(final org.atilika.kuromoji.Token token) {
+    public Token(final com.atilika.kuromoji.ipadic.Token token) {
         this.token = token;
         this.feature = token.getAllFeaturesArray();
     }
@@ -23,9 +23,9 @@ public class Token {
         if (this.pronunciationLength == null) {
             String reading = pronunciation();
             if (reading.equals("")) {
-                final String surfaceForm = token.getSurfaceForm();
+                final String surfaceForm = token.getSurface();
                 if (surfaceForm != null && !StringUtils.isPureAscii(surfaceForm)) {
-                    reading = zenkakuHiraganaToZenkakuKatakana(token.getSurfaceForm());
+                    reading = zenkakuHiraganaToZenkakuKatakana(token.getSurface());
                 }
             }
 
@@ -67,7 +67,7 @@ public class Token {
     }
 
     boolean notElementOfIkku() {
-        return this.token.isUnknown();
+        return !this.token.isKnown();
     }
 
     boolean lastOfPhrase() {
@@ -133,6 +133,6 @@ public class Token {
 
     @Override
     public String toString() {
-        return token.getSurfaceForm();
+        return token.getSurface();
     }
 }


### PR DESCRIPTION
・kuromojiライブラリのリポジトリurlを変更
・kuromojiライブラリを0.9.0に更新
・ライブラリ更新で発生したメソッド名の変更に追随
　getSurfaceFrom -> getSurface
　getUnknown -> !getKnown
・プロジェクトのデフォルトエンコードをutf-8に
・プロジェクトがエラーで読み込めなかったのでossrhUsernameとossrhPasswordのproperty設定がなかったらパスするように変更
